### PR TITLE
Embded http.Request in httpnoquery.Request

### DIFF
--- a/httpnoquery.go
+++ b/httpnoquery.go
@@ -11,15 +11,13 @@ import (
 	"net/url"
 )
 
-// Request is sent by this client. It was created to make it less
-// possible to mess up and use a regular http.Client to send data.
+// Request is sent by this client. It was created so it was more
+// apparent by looking at the types that this is a new type of request
+// so it should be sent with a new kind of client (i.e I wanted to
+// make it less possible to mess up and use a regular http.Client to
+// send requests).
 type Request struct {
-	request *http.Request
-}
-
-// NewRequest creates a Request.
-func NewRequest(r *http.Request) Request {
-	return Request{r}
+	*http.Request
 }
 
 // Client sends http requests and modifies the returned error so it
@@ -38,9 +36,9 @@ func (c Client) httpClient() *http.Client {
 // Do sends the request and removes any query string from the returned
 // error message.
 func (c Client) Do(r Request) (*http.Response, error) {
-	resp, err := c.httpClient().Do(r.request)
+	resp, err := c.httpClient().Do(r.Request)
 	if urlErr, ok := err.(*url.Error); ok {
-		urlNoQuery := *r.request.URL
+		urlNoQuery := *r.URL
 		urlNoQuery.RawQuery = ""
 		return resp, fmt.Errorf("sending request: %s %s: %v", urlErr.Op, urlNoQuery.String(), urlErr.Err)
 	}

--- a/httpnoquery_test.go
+++ b/httpnoquery_test.go
@@ -38,7 +38,7 @@ func TestClientDo(t *testing.T) {
 			if err != nil {
 				panic(err)
 			}
-			resp, err := client.Do(httpnoquery.NewRequest(req))
+			resp, err := client.Do(httpnoquery.Request{req})
 			if err != nil {
 				t.Errorf("got non-nil error: %v", err)
 			}
@@ -62,7 +62,7 @@ func TestClientDoNoQueryStr(t *testing.T) {
 	if err != nil {
 		panic(err)
 	}
-	_, err = client.Do(httpnoquery.NewRequest(req))
+	_, err = client.Do(httpnoquery.Request{req})
 	if got, want := fmt.Sprintf("%v", err), "sending request: Get /path:"; !strings.Contains(got, want) {
 		t.Errorf("error string %s should contain the message %s", got, want)
 	}


### PR DESCRIPTION
I realized that testing whether the correct request is generated could be
more annoying if you cannot access the inner request. So I embedded it.